### PR TITLE
feat: Add separator characters

### DIFF
--- a/src/no-doubled-conjunction.js
+++ b/src/no-doubled-conjunction.js
@@ -25,7 +25,7 @@ export default function (context, options = {}) {
             const text = source.toString();
             const isSentenceNode = (node) => node.type === SentenceSyntax.Sentence;
             let sentences = splitSentences(text, {
-                charRegExp: /[。\?\!？！]/
+                charRegExp: /[.．。\?\!？！]/
             }).filter(isSentenceNode);
             // if not have a sentence, early return
             // It is for avoiding error of emptyArray.reduce().

--- a/test/no-doubled-conjunction.js
+++ b/test/no-doubled-conjunction.js
@@ -41,7 +41,18 @@ tester.run("no-doubled-conjunction", rule, {
                   column: 53
               }
           ]
-      }
+      },
+      {
+        text: "かな漢字変換により漢字が多用される傾向がある．しかし漢字の多用が読みにくさをもたらす側面は否定できない.しかし、平仮名が多い文は間延びした印象を与える恐れもある。",
+        errors: [
+            {
+                message: `同じ接続詞が連続して使われています。`,
+                // last match
+                line: 1,
+                column: 53
+            }
+        ]
+      }   
 
     ]
 });


### PR DESCRIPTION
Hello.

This PR adds "."(period) & "．"(Zenkaku period) as separator characters to detect double conjunction in sentences that use these.
These are added in [textlint-ja/textlint-rule-no-doubled-joshi](https://github.com/textlint-ja/textlint-rule-no-doubled-joshi) already.

Note : 
According to the [IPSJ journal](https://www.ipsj.or.jp/journal/submit/ronbun_j_prms.html),  Using “zenkaku period” is recommended.

> コンマおよびピリオドの使い方：
>　・和文には、全角コンマ、全角コロン、全角ピリオドを用いる。
