### PR TITLE
fix(deps): update to kuromojin@3 and 全角ピリオド対応

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1105,8 +1105,7 @@
     "@textlint/ast-node-types": {
       "version": "4.3.4",
       "resolved": "https://registry.npmjs.org/@textlint/ast-node-types/-/ast-node-types-4.3.4.tgz",
-      "integrity": "sha512-Grq+vJuNH7HCa278eFeiqJvowrD+onMCoG2ctLyoN+fXYIQGIr1/8fo8AcIg+VM16Kga+N6Y1UWNOWPd8j1nFg==",
-      "dev": true
+      "integrity": "sha512-Grq+vJuNH7HCa278eFeiqJvowrD+onMCoG2ctLyoN+fXYIQGIr1/8fo8AcIg+VM16Kga+N6Y1UWNOWPd8j1nFg=="
     },
     "@textlint/ast-tester": {
       "version": "2.2.4",
@@ -1344,7 +1343,6 @@
       "version": "1.4.5",
       "resolved": "https://registry.npmjs.org/@textlint/types/-/types-1.4.5.tgz",
       "integrity": "sha512-7pA1rdiw1jsDNGwxupMC6fPlRNAHY6fKZ3s+jAY53o6RroOSR+5qO0sAjJ26lsSOhveH8imZzyyD08dk58IVJQ==",
-      "dev": true,
       "requires": {
         "@textlint/ast-node-types": "^4.3.4"
       }
@@ -1354,6 +1352,16 @@
       "resolved": "https://registry.npmjs.org/@textlint/utils/-/utils-1.1.4.tgz",
       "integrity": "sha512-KmU+kGi7vG5toUhNdLHHPxyVN1mNGcjMVe1tNDEXT1wU/3oqA96bunElrROWHYw5iNt1QVRaIAtNeMVyzyAdVA==",
       "dev": true
+    },
+    "@types/structured-source": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@types/structured-source/-/structured-source-3.0.0.tgz",
+      "integrity": "sha512-8u+Wo5+GEXe4jZyQ8TplLp+1A7g32ZcVoE7VZu8VcxnlaEm5I/+T579R7q3qKN76jmK0lRshpo4hl4bj/kEPKA=="
+    },
+    "@types/unist": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/@types/unist/-/unist-2.0.3.tgz",
+      "integrity": "sha512-FvUupuM3rlRsRtCN+fDudtmytGO6iHJuuRKS1Ss0pG5z8oX0diNEw94UEL7hgDbpN94rgaK5R7sWm6RrSkZuAQ=="
     },
     "ajv": {
       "version": "4.11.8",
@@ -1509,8 +1517,7 @@
     "bail": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/bail/-/bail-1.0.5.tgz",
-      "integrity": "sha512-xFbRxM1tahm08yHBP16MMjVUAvDaBMD38zsM9EMAUN61omwLmKlOpB/Zku5QkjZ8TZ4vn53pj+t518cH0S03RQ==",
-      "dev": true
+      "integrity": "sha512-xFbRxM1tahm08yHBP16MMjVUAvDaBMD38zsM9EMAUN61omwLmKlOpB/Zku5QkjZ8TZ4vn53pj+t518cH0S03RQ=="
     },
     "balanced-match": {
       "version": "1.0.0",
@@ -1729,6 +1736,11 @@
       "integrity": "sha512-XqSQKt9Fd3Z9BoN0cpSaITcTInKhMNGkaWtQ4rDnyQU1BJzzWDWCUi3cJflaPWk2kbrkYkfMrMrjIFzb3kd6NQ==",
       "dev": true
     },
+    "ccount": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/ccount/-/ccount-1.1.0.tgz",
+      "integrity": "sha512-vlNK021QdI7PNeiUh/lKkC/mNHHfV0m/Ad5JoI0TYtlBnJAslM/JIkm/tGC88bkLIwO6OQ5uV6ztS6kVAtCDlg=="
+    },
     "chalk": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
@@ -1901,6 +1913,11 @@
       "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
       "dev": true
     },
+    "comma-separated-tokens": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/comma-separated-tokens/-/comma-separated-tokens-1.0.8.tgz",
+      "integrity": "sha512-GHuDRO12Sypu2cV70d1dkA2EUmXHgntrzbpvOB+Qy+49ypNfGgFQIC2fhhXbnyrJRynDCAARsT7Ou0M6hirpfw=="
+    },
     "commander": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/commander/-/commander-4.1.1.tgz",
@@ -1930,6 +1947,7 @@
       "version": "1.6.2",
       "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.2.tgz",
       "integrity": "sha512-27HBghJxjiZtIk3Ycvn/4kbJk/1uZuJFfuPEns6LaEvpvG1f0hTea8lilrouyo9mVc2GWdcEZ8OLoGmSADlrCw==",
+      "dev": true,
       "requires": {
         "buffer-from": "^1.0.0",
         "inherits": "^2.0.3",
@@ -1980,7 +1998,8 @@
     "core-util-is": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
+      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
+      "dev": true
     },
     "cross-spawn": {
       "version": "7.0.3",
@@ -2244,8 +2263,7 @@
     "extend": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
-      "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
-      "dev": true
+      "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g=="
     },
     "extend-shallow": {
       "version": "3.0.2",
@@ -2648,6 +2666,34 @@
         }
       }
     },
+    "hast-util-from-parse5": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/hast-util-from-parse5/-/hast-util-from-parse5-5.0.3.tgz",
+      "integrity": "sha512-gOc8UB99F6eWVWFtM9jUikjN7QkWxB3nY0df5Z0Zq1/Nkwl5V4hAAsl0tmwlgWl/1shlTF8DnNYLO8X6wRV9pA==",
+      "requires": {
+        "ccount": "^1.0.3",
+        "hastscript": "^5.0.0",
+        "property-information": "^5.0.0",
+        "web-namespaces": "^1.1.2",
+        "xtend": "^4.0.1"
+      }
+    },
+    "hast-util-parse-selector": {
+      "version": "2.2.5",
+      "resolved": "https://registry.npmjs.org/hast-util-parse-selector/-/hast-util-parse-selector-2.2.5.tgz",
+      "integrity": "sha512-7j6mrk/qqkSehsM92wQjdIgWM2/BW61u/53G6xmC8i1OmEdKLHbk419QKQUjz6LglWsfqoiHmyMRkP1BGjecNQ=="
+    },
+    "hastscript": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/hastscript/-/hastscript-5.1.2.tgz",
+      "integrity": "sha512-WlztFuK+Lrvi3EggsqOkQ52rKbxkXL3RwB6t5lwoa8QLMemoWfBuL43eDrwOamJyR7uKQKdmKYaBH1NZBiIRrQ==",
+      "requires": {
+        "comma-separated-tokens": "^1.0.0",
+        "hast-util-parse-selector": "^2.0.0",
+        "property-information": "^5.0.0",
+        "space-separated-tokens": "^1.0.0"
+      }
+    },
     "he": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/he/-/he-1.2.0.tgz",
@@ -2955,7 +3001,8 @@
     "isarray": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
+      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+      "dev": true
     },
     "isexe": {
       "version": "2.0.0",
@@ -3030,21 +3077,22 @@
       "optional": true
     },
     "kuromoji": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/kuromoji/-/kuromoji-0.1.1.tgz",
-      "integrity": "sha1-Sqvzm8zti4rZLQB6BKJr5tqEd8k=",
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/kuromoji/-/kuromoji-0.1.2.tgz",
+      "integrity": "sha512-V0dUf+C2LpcPEXhoHLMAop/bOht16Dyr+mDiIE39yX3vqau7p80De/koFqpiTcL1zzdZlc3xuHZ8u5gjYRfFaQ==",
       "requires": {
         "async": "^2.0.1",
         "doublearray": "0.0.2",
-        "zlibjs": "^0.2.0"
+        "zlibjs": "^0.3.1"
       }
     },
     "kuromojin": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/kuromojin/-/kuromojin-2.0.0.tgz",
-      "integrity": "sha512-60j/yLkFSc4t4roj8tI8ZNNSiAFnrkgXw8SqXz/9nakfs6mkCvPbrd7S8LDr4YNwEt1IyLys5JQTR9EnYyGHhA==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/kuromojin/-/kuromojin-3.0.0.tgz",
+      "integrity": "sha512-3h3qnn/NVVhqoKFP4oc7e6apO2B01Atc056oiVlIY7Uoup4rhrnBe28g3y9lK1HTmLDQEejvXB+3I3qxAneF7A==",
       "requires": {
-        "kuromoji": "0.1.1"
+        "kuromoji": "0.1.2",
+        "lru_map": "^0.4.1"
       }
     },
     "leven": {
@@ -3166,6 +3214,11 @@
         "currently-unhandled": "^0.4.1",
         "signal-exit": "^3.0.0"
       }
+    },
+    "lru_map": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/lru_map/-/lru_map-0.4.1.tgz",
+      "integrity": "sha512-I+lBvqMMFfqaV8CJCISjI3wbjmwVu/VyOoU7+qtu9d7ioW5klMgsTTiUOUp+DJvfTTzKXoPbyC6YfgkNcyPSOg=="
     },
     "make-dir": {
       "version": "2.1.0",
@@ -3505,7 +3558,8 @@
     "object-assign": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-      "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
+      "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
+      "dev": true
     },
     "object-copy": {
       "version": "0.1.0",
@@ -3605,6 +3659,11 @@
         "isobject": "^3.0.1"
       }
     },
+    "object_values": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/object_values/-/object_values-0.1.2.tgz",
+      "integrity": "sha512-tZgUiKLraVH+4OAedBYrr4/K6KmAQw2RPNd1AuNdhLsuz5WP3VB7WuiKBWbOcjeqqAjus2ChIIWC8dSfmg7ReA=="
+    },
     "once": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
@@ -3674,6 +3733,11 @@
       "requires": {
         "error-ex": "^1.2.0"
       }
+    },
+    "parse5": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-5.1.1.tgz",
+      "integrity": "sha512-ugq4DFI0Ptb+WWjAdOK16+u/nHfiIrcE+sh8kZMaM0WllQKLI9rOUq6c2b7cwPkXdzfQESqvoqK6ug7U/Yyzug=="
     },
     "pascalcase": {
       "version": "0.1.1",
@@ -3824,7 +3888,16 @@
     "process-nextick-args": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
-      "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag=="
+      "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
+      "dev": true
+    },
+    "property-information": {
+      "version": "5.6.0",
+      "resolved": "https://registry.npmjs.org/property-information/-/property-information-5.6.0.tgz",
+      "integrity": "sha512-YUHSPk+A30YPv+0Qf8i9Mbfe/C0hdPXk1s1jPVToV8pk8BQtpw10ct89Eo7OWkutrwqvT0eicAxlOg3dOAu8JA==",
+      "requires": {
+        "xtend": "^4.0.0"
+      }
     },
     "rc-config-loader": {
       "version": "3.0.0",
@@ -3901,6 +3974,7 @@
       "version": "2.3.7",
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
       "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
+      "dev": true,
       "requires": {
         "core-util-is": "~1.0.0",
         "inherits": "~2.0.3",
@@ -4021,6 +4095,16 @@
         }
       }
     },
+    "rehype-parse": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/rehype-parse/-/rehype-parse-6.0.2.tgz",
+      "integrity": "sha512-0S3CpvpTAgGmnz8kiCyFLGuW5yA4OQhyNTm/nwPopZ7+PI11WnGl1TTWTGv/2hPEe/g2jRLlhVVSsoDH8waRug==",
+      "requires": {
+        "hast-util-from-parse5": "^5.0.0",
+        "parse5": "^5.0.0",
+        "xtend": "^4.0.0"
+      }
+    },
     "remark-frontmatter": {
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/remark-frontmatter/-/remark-frontmatter-1.3.3.tgz",
@@ -4138,12 +4222,42 @@
       "dev": true
     },
     "sentence-splitter": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/sentence-splitter/-/sentence-splitter-2.3.2.tgz",
-      "integrity": "sha512-QnpHNykm4nI4T6mT+NoVayh9Ixl5DohYCSVqMgPJsO2WejOcqaYTh4HQOkmzaDzXH3NO5pif4z/hpo2NGtgNlg==",
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/sentence-splitter/-/sentence-splitter-3.2.1.tgz",
+      "integrity": "sha512-aG+Tf8M1wVUd2uPSUtdMXdJlKZLcdh+oVE8iEn8KwfxYZ87qDpe7+o0nGZdr+96g2H76Qz/8TrG9dIxyp7c70w==",
       "requires": {
-        "concat-stream": "^1.5.2",
+        "@textlint/ast-node-types": "^4.4.2",
+        "concat-stream": "^2.0.0",
+        "object_values": "^0.1.2",
         "structured-source": "^3.0.2"
+      },
+      "dependencies": {
+        "@textlint/ast-node-types": {
+          "version": "4.4.2",
+          "resolved": "https://registry.npmjs.org/@textlint/ast-node-types/-/ast-node-types-4.4.2.tgz",
+          "integrity": "sha512-m5brKbI7UY/Q8sbIZ7z1KB8ls04nRILshz5fPQ4EZ04jL19qrrUHJR8A6nK3vJ/GelkDWl4I0VDYSAjLEFQV8g=="
+        },
+        "concat-stream": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-2.0.0.tgz",
+          "integrity": "sha512-MWufYdFw53ccGjCA+Ol7XJYpAlW6/prSMzuPOTRnJGcGzuhLn4Scrz7qf6o8bROZ514ltazcIFJZevcfbo0x7A==",
+          "requires": {
+            "buffer-from": "^1.0.0",
+            "inherits": "^2.0.3",
+            "readable-stream": "^3.0.2",
+            "typedarray": "^0.0.6"
+          }
+        },
+        "readable-stream": {
+          "version": "3.6.0",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
+          "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
+          "requires": {
+            "inherits": "^2.0.3",
+            "string_decoder": "^1.1.1",
+            "util-deprecate": "^1.0.1"
+          }
+        }
       }
     },
     "set-blocking": {
@@ -4372,6 +4486,11 @@
       "dev": true,
       "optional": true
     },
+    "space-separated-tokens": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/space-separated-tokens/-/space-separated-tokens-1.1.5.tgz",
+      "integrity": "sha512-q/JSVd1Lptzhf5bkYm4ob4iWPjx0KiRe3sRFBNrVqbJkFaBm5vbbowy1mymoPNLRa52+oadOhJ+K49wsSeSjTA=="
+    },
     "spdx-correct": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-3.1.1.tgz",
@@ -4583,10 +4702,13 @@
       "dev": true
     },
     "textlint-rule-helper": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/textlint-rule-helper/-/textlint-rule-helper-1.2.0.tgz",
-      "integrity": "sha1-vmjUelFGsW3RFieMmut701YxzNo=",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/textlint-rule-helper/-/textlint-rule-helper-2.1.1.tgz",
+      "integrity": "sha512-6fxgHzoJVkjl3LaC1b2Egi+5wbhG4i0pU0knJmQujVhxIJ3D3AcQQZPs457xKAi5xKz1WayYeTeJ5jrD/hnO7g==",
       "requires": {
+        "@textlint/ast-node-types": "^4.2.1",
+        "@textlint/types": "^1.1.2",
+        "structured-source": "^3.0.2",
         "unist-util-visit": "^1.1.0"
       }
     },
@@ -4839,12 +4961,15 @@
       }
     },
     "textlint-util-to-string": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/textlint-util-to-string/-/textlint-util-to-string-1.2.1.tgz",
-      "integrity": "sha1-HPiZVtJ1VaVelYjAazWlDw0dRvk=",
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/textlint-util-to-string/-/textlint-util-to-string-3.1.1.tgz",
+      "integrity": "sha512-mHE7/pDw/Hk+Q6YdSMNRrZPl5bCuWnFLbF+bxW+MsWQ64dw+Ia9irkammYbH5I0hVMMcfwb0MQc5nbsjqgWeyQ==",
       "requires": {
-        "object-assign": "^4.0.1",
-        "structured-source": "^3.0.2"
+        "@textlint/ast-node-types": "^4.2.4",
+        "@types/structured-source": "^3.0.0",
+        "rehype-parse": "^6.0.1",
+        "structured-source": "^3.0.2",
+        "unified": "^8.4.0"
       }
     },
     "to-fast-properties": {
@@ -4926,8 +5051,7 @@
     "trough": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/trough/-/trough-1.0.5.tgz",
-      "integrity": "sha512-rvuRbTarPXmMb79SmzEp8aqXNKcK+y0XaB298IXueQ8I2PsrATcPBCSPyK/dDNa2iWOhKlfNnOjdAOTBU/nkFA==",
-      "dev": true
+      "integrity": "sha512-rvuRbTarPXmMb79SmzEp8aqXNKcK+y0XaB298IXueQ8I2PsrATcPBCSPyK/dDNa2iWOhKlfNnOjdAOTBU/nkFA=="
     },
     "try-resolve": {
       "version": "1.0.1",
@@ -4986,6 +5110,25 @@
       "resolved": "https://registry.npmjs.org/unicode-property-aliases-ecmascript/-/unicode-property-aliases-ecmascript-1.1.0.tgz",
       "integrity": "sha512-PqSoPh/pWetQ2phoj5RLiaqIk4kCNwoV3CI+LfGmWLKI3rE3kl1h59XpX2BjgDrmbxD9ARtQobPGU1SguCYuQg==",
       "dev": true
+    },
+    "unified": {
+      "version": "8.4.2",
+      "resolved": "https://registry.npmjs.org/unified/-/unified-8.4.2.tgz",
+      "integrity": "sha512-JCrmN13jI4+h9UAyKEoGcDZV+i1E7BLFuG7OsaDvTXI5P0qhHX+vZO/kOhz9jn8HGENDKbwSeB0nVOg4gVStGA==",
+      "requires": {
+        "bail": "^1.0.0",
+        "extend": "^3.0.0",
+        "is-plain-obj": "^2.0.0",
+        "trough": "^1.0.0",
+        "vfile": "^4.0.0"
+      },
+      "dependencies": {
+        "is-plain-obj": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-2.1.0.tgz",
+          "integrity": "sha512-YWnfyRwxL/+SsrWYfOpUtz5b3YD+nyfkHvjbcanzk8zgyO4ASD67uVMRt8k5bM4lLMDnXfriRhOpemw+NfT1eA=="
+        }
+      }
     },
     "union-value": {
       "version": "1.0.1",
@@ -5122,6 +5265,41 @@
         "spdx-expression-parse": "^3.0.0"
       }
     },
+    "vfile": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/vfile/-/vfile-4.2.1.tgz",
+      "integrity": "sha512-O6AE4OskCG5S1emQ/4gl8zK586RqA3srz3nfK/Viy0UPToBc5Trp9BVFb1u0CjsKrAWwnpr4ifM/KBXPWwJbCA==",
+      "requires": {
+        "@types/unist": "^2.0.0",
+        "is-buffer": "^2.0.0",
+        "unist-util-stringify-position": "^2.0.0",
+        "vfile-message": "^2.0.0"
+      },
+      "dependencies": {
+        "is-buffer": {
+          "version": "2.0.5",
+          "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-2.0.5.tgz",
+          "integrity": "sha512-i2R6zNFDwgEHJyQUtJEk0XFi1i0dPFn/oqjK3/vPCcDeJvW5NQ83V8QbicfF1SupOaB0h8ntgBC2YiE7dfyctQ=="
+        },
+        "unist-util-stringify-position": {
+          "version": "2.0.3",
+          "resolved": "https://registry.npmjs.org/unist-util-stringify-position/-/unist-util-stringify-position-2.0.3.tgz",
+          "integrity": "sha512-3faScn5I+hy9VleOq/qNbAd6pAx7iH5jYBMS9I1HgQVijz/4mv5Bvw5iw1sC/90CODiKo81G/ps8AJrISn687g==",
+          "requires": {
+            "@types/unist": "^2.0.2"
+          }
+        },
+        "vfile-message": {
+          "version": "2.0.4",
+          "resolved": "https://registry.npmjs.org/vfile-message/-/vfile-message-2.0.4.tgz",
+          "integrity": "sha512-DjssxRGkMvifUOJre00juHoP9DPWuzjxKuMDrhNbk2TdaYYBNMStsNhEOt3idrtI12VQYM/1+iM0KOzXi4pxwQ==",
+          "requires": {
+            "@types/unist": "^2.0.0",
+            "unist-util-stringify-position": "^2.0.0"
+          }
+        }
+      }
+    },
     "vfile-location": {
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/vfile-location/-/vfile-location-2.0.6.tgz",
@@ -5136,6 +5314,11 @@
       "requires": {
         "unist-util-stringify-position": "^1.1.1"
       }
+    },
+    "web-namespaces": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/web-namespaces/-/web-namespaces-1.1.4.tgz",
+      "integrity": "sha512-wYxSGajtmoP4WxfejAPIr4l0fVh+jeMXZb08wNc0tMg6xsfZXj3cECqIK0G7ZAqUq0PP8WlMDtaOGVBTAWztNw=="
     },
     "which": {
       "version": "2.0.2",
@@ -5251,8 +5434,7 @@
     "xtend": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
-      "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==",
-      "dev": true
+      "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ=="
     },
     "y18n": {
       "version": "4.0.0",
@@ -5334,9 +5516,9 @@
       }
     },
     "zlibjs": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/zlibjs/-/zlibjs-0.2.0.tgz",
-      "integrity": "sha1-riDwYkMpPYXCVVYxifmxL1s7oaA="
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/zlibjs/-/zlibjs-0.3.1.tgz",
+      "integrity": "sha1-UBl+2yihxCymWcyLTmqd3W1ERVQ="
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -8,10 +8,10 @@
     "test": "test"
   },
   "dependencies": {
-    "kuromojin": "^2.0.0",
-    "sentence-splitter": "^2.0.0",
-    "textlint-rule-helper": "^1.1.5",
-    "textlint-util-to-string": "^1.2.0"
+    "kuromojin": "^3.0.0",
+    "sentence-splitter": "^3.2.1",
+    "textlint-rule-helper": "^2.1.1",
+    "textlint-util-to-string": "^3.1.1"
   },
   "devDependencies": {
     "textlint-scripts": "^3.0.0"

--- a/src/no-doubled-conjunction.js
+++ b/src/no-doubled-conjunction.js
@@ -24,8 +24,18 @@ export default function (context, options = {}) {
             const source = new StringSource(node);
             const text = source.toString();
             const isSentenceNode = (node) => node.type === SentenceSyntax.Sentence;
-            let sentences = splitSentences(text, {
-                charRegExp: /[。\?\!？！]/
+            const sentences = splitSentences(text, {
+                SeparatorParser: {
+                    separatorCharacters: [
+                        ".", // period
+                        "．", // (ja) zenkaku-period
+                        "。", // (ja) 句点
+                        "?", // question mark
+                        "!", //  exclamation mark
+                        "？", // (ja) zenkaku question mark
+                        "！" // (ja) zenkaku exclamation mark
+                    ]
+                }
             }).filter(isSentenceNode);
             // if not have a sentence, early return
             // It is for avoiding error of emptyArray.reduce().

--- a/src/no-doubled-conjunction.js
+++ b/src/no-doubled-conjunction.js
@@ -1,9 +1,9 @@
 // LICENSE : MIT
 "use strict";
-import {RuleHelper} from "textlint-rule-helper";
-import {getTokenizer} from "kuromojin";
-import {split as splitSentences, Syntax as SentenceSyntax} from "sentence-splitter";
-import StringSource from "textlint-util-to-string";
+import { RuleHelper } from "textlint-rule-helper";
+import { getTokenizer } from "kuromojin";
+import { split as splitSentences, Syntax as SentenceSyntax } from "sentence-splitter";
+import { StringSource } from "textlint-util-to-string";
 
 /*
     1. Paragraph Node -> text
@@ -15,9 +15,9 @@ import StringSource from "textlint-util-to-string";
  */
 export default function (context, options = {}) {
     const helper = new RuleHelper(context);
-    const {Syntax, report, getSource, RuleError} = context;
+    const { Syntax, report, getSource, RuleError } = context;
     return {
-        [Syntax.Paragraph](node){
+        [Syntax.Paragraph](node) {
             if (helper.isChildNode(node, [Syntax.Link, Syntax.Image, Syntax.BlockQuote, Syntax.Emphasis])) {
                 return;
             }
@@ -29,39 +29,39 @@ export default function (context, options = {}) {
             }).filter(isSentenceNode);
             // if not have a sentence, early return
             // It is for avoiding error of emptyArray.reduce().
-            if(sentences.length === 0) {
+            if (sentences.length === 0) {
                 return;
             }
             return getTokenizer().then(tokenizer => {
-              const selectConjenction = (sentence) => {
-                let tokens = tokenizer.tokenizeForSentence(sentence.raw);
-                let conjunctionTokens = tokens.filter((token) => token.pos === "接続詞");
-                return [sentence, conjunctionTokens];
-              };
-              let prev_token = null;
-              sentences.map(selectConjenction).reduce((prev, current) => {
-                let token = prev_token;
-                let [sentence, current_tokens] = current;
-                let [prev_sentence, prev_tokens] = prev;
-                if (prev_tokens && prev_tokens.length > 0) {
-                  token = prev_tokens[0];
-                }
-                if (current_tokens.length > 0) {
-                  if (token && current_tokens[0].surface_form === token.surface_form) {
-                    let originalIndex = source.originalIndexFromPosition({
-                      line: sentence.loc.start.line,
-                      column: sentence.loc.start.column + (current_tokens[0].word_position - 1)
-                    });
-                    // padding position
-                    var padding = {
-                        index: originalIndex
-                    };
-                    report(node, new RuleError(`同じ接続詞が連続して使われています。`, padding));
-                  }
-                }
-                prev_token = token;
-                return current;
-              });
+                const selectConjenction = (sentence) => {
+                    const tokens = tokenizer.tokenizeForSentence(sentence.raw);
+                    const conjunctionTokens = tokens.filter((token) => token.pos === "接続詞");
+                    return [sentence, conjunctionTokens];
+                };
+                let prev_token = null;
+                sentences.map(selectConjenction).reduce((prev, current) => {
+                    const [sentence, current_tokens] = current;
+                    const [prev_sentence, prev_tokens] = prev;
+                    let token = prev_token;
+                    if (prev_tokens && prev_tokens.length > 0) {
+                        token = prev_tokens[0];
+                    }
+                    if (current_tokens.length > 0) {
+                        if (token && current_tokens[0].surface_form === token.surface_form) {
+                            const originalIndex = source.originalIndexFromPosition({
+                                line: sentence.loc.start.line,
+                                column: sentence.loc.start.column + (current_tokens[0].word_position - 1)
+                            });
+                            // padding position
+                            const padding = {
+                                index: originalIndex
+                            };
+                            report(node, new RuleError(`同じ接続詞が連続して使われています。`, padding));
+                        }
+                    }
+                    prev_token = token;
+                    return current;
+                });
             });
         }
     }

--- a/src/no-doubled-conjunction.js
+++ b/src/no-doubled-conjunction.js
@@ -58,6 +58,7 @@ export default function (context, options = {}) {
                     }
                     if (current_tokens.length > 0) {
                         if (token && current_tokens[0].surface_form === token.surface_form) {
+                            const conjunctionSurface = token.surface_form;
                             const originalIndex = source.originalIndexFromPosition({
                                 line: sentence.loc.start.line,
                                 column: sentence.loc.start.column + (current_tokens[0].word_position - 1)
@@ -66,7 +67,7 @@ export default function (context, options = {}) {
                             const padding = {
                                 index: originalIndex
                             };
-                            report(node, new RuleError(`同じ接続詞が連続して使われています。`, padding));
+                            report(node, new RuleError(`同じ接続詞（${conjunctionSurface}）が連続して使われています。`, padding));
                         }
                     }
                     prev_token = token;

--- a/test/no-doubled-conjunction.js
+++ b/test/no-doubled-conjunction.js
@@ -1,5 +1,6 @@
 import rule from "../src/no-doubled-conjunction";
 import TextLintTester from "textlint-tester";
+
 var tester = new TextLintTester();
 tester.run("no-doubled-conjunction", rule, {
     valid: [
@@ -9,39 +10,47 @@ tester.run("no-doubled-conjunction", rule, {
         "![](path/to/image.png)"// empty image label
     ],
     invalid: [
-      {
-          text: "朝起きた。そして昼は仕事をした。そして夜に寝た",
-          errors: [
-              {
-                  message: `同じ接続詞が連続して使われています。`,
-                  // last match
-                  line: 1,
-                  column: 17
-              }
-          ]
-      },
-      {
-          text: "そして朝起きた。昼は仕事をした。そして夜に寝た",
-          errors: [
-              {
-                  message: `同じ接続詞が連続して使われています。`,
-                  // last match
-                  line: 1,
-                  column: 17
-              }
-          ]
-      },
-      {
-          text: "かな漢字変換により漢字が多用される傾向がある。しかし漢字の多用が読みにくさをもたらす側面は否定できない。しかし、平仮名が多い文は間延びした印象を与える恐れもある。",
-          errors: [
-              {
-                  message: `同じ接続詞が連続して使われています。`,
-                  // last match
-                  line: 1,
-                  column: 53
-              }
-          ]
-      }
-
+        {
+            text: "朝起きた。そして昼は仕事をした。そして夜に寝た",
+            errors: [
+                {
+                    message: `同じ接続詞（そして）が連続して使われています。`,
+                    // last match
+                    line: 1,
+                    column: 17
+                }
+            ]
+        },
+        {
+            text: "そして朝起きた。昼は仕事をした。そして夜に寝た",
+            errors: [
+                {
+                    message: `同じ接続詞（そして）が連続して使われています。`,
+                    // last match
+                    line: 1,
+                    column: 17
+                }
+            ]
+        },
+        {
+            text: "かな漢字変換により漢字が多用される傾向がある。しかし漢字の多用が読みにくさをもたらす側面は否定できない。しかし、平仮名が多い文は間延びした印象を与える恐れもある。",
+            errors: [
+                {
+                    message: `同じ接続詞（しかし）が連続して使われています。`,
+                    // last match
+                    line: 1,
+                    column: 53
+                }
+            ]
+        },
+        {
+            text: "かな漢字変換により漢字が多用される傾向がある．しかし漢字の多用が読みにくさをもたらす側面は否定できない. しかし、平仮名が多い文は間延びした印象を与える恐れもある。",
+            errors: [
+                {
+                    message: `同じ接続詞（しかし）が連続して使われています。`,
+                    index: 53
+                }
+            ]
+        }
     ]
 });


### PR DESCRIPTION
## Summary

- Update to [kuromojin@3](https://github.com/azu/kuromojin/releases/tag/v3.0.0) and improve analysis.
- 全角ピリオド（`．`）の対応 fix #6 
- エラーメッセージの改善

## Features

- 全角ピリオド（`．`）の対応 fix #6 
- エラーメッセージの改善

##  Bug Fixes

- Update to [kuromojin@3](https://github.com/azu/kuromojin/releases/tag/v3.0.0)
  - refs https://github.com/azu/kuromojin/issues/8
- Update to [sentence-splitter@3](https://github.com/azu/sentence-splitter/releases/tag/3.0.0)

## CI

- Move to GitHub Actions