### PR TITLE
fix: report doubled conjunction at the later occurrence's position

### DIFF
--- a/src/no-doubled-conjunction.js
+++ b/src/no-doubled-conjunction.js
@@ -68,13 +68,15 @@ export default function (context, options = {}) {
                 }
                 if (current_tokens.length > 0) {
                     if (token && current_tokens[0].surface_form === token.surface_form) {
-                        const conjunctionSurface = token.surface_form;
+                        // report() targets the current `sentence`, so base the padding on its
+                        // own conjunction; `token` is the previous sentence's and mis-offsets.
+                        const conjunctionSurface = current_tokens[0].surface_form;
                         // padding position
                         report(sentence,
                             new RuleError(`同じ接続詞（${conjunctionSurface}）が連続して使われています。`, {
                                 padding: locator.range([
-                                    token.word_position - 1,
-                                    token.word_position + conjunctionSurface.length - 1
+                                    current_tokens[0].word_position - 1,
+                                    current_tokens[0].word_position + conjunctionSurface.length - 1
                                 ])
                             }));
                     }

--- a/test/no-doubled-conjunction.js
+++ b/test/no-doubled-conjunction.js
@@ -102,5 +102,16 @@ tester.run("no-doubled-conjunction", rule, {
                 }
             ]
         },
+        {
+            // preceding conjunction is mid-sentence (after a comma), not at the head
+            text: "天気はとても良くて、また気温も快適です。空はあおいです。また、風も心地よいです。",
+            errors: [
+                {
+                    message: `同じ接続詞（また）が連続して使われています。`,
+                    // last match
+                    range: [28, 30]
+                }
+            ]
+        },
     ]
 });


### PR DESCRIPTION
## Problem

The error location can be wrong when the **preceding** conjunction is not at the head of its sentence.

The error is reported on the current (later) `sentence` node, but the `padding` range is computed from the **previous** sentence's token (`token.word_position`). Those two values live in different coordinate systems, so the reported range no longer covers the conjunction — and can even fall outside the text.

It happens to be correct only when both conjunctions sit at the head of their sentences (where `token` and `current_tokens[0]` share the same in-sentence offset), which is why every existing fixture passes and the bug stayed hidden. This is a follow-up to the location work in #18 / #29.

### Reproduction

```
天気はとても良くて、また気温も快適です。空はあおいです。また、風も心地よいです。
```

The second `また` is at `[28, 30]`, but the rule reports `[38, 40]` (which points at `す。`, not a conjunction).

## Fix

Compute the padding from the current sentence's conjunction (`current_tokens[0]`) instead of the previous sentence's `token`, so the later occurrence (the "last match" the existing tests expect) is highlighted.

## Tests

- All existing fixtures are unchanged and still pass (they place conjunctions at the sentence head, where the bug is masked).
- Added a regression fixture with a mid-sentence preceding conjunction, asserting the corrected `range: [28, 30]`. It fails on `master` (`[38, 40]`) and passes with this change.

`npm test` → 14 passing.