### PR TITLE
ci: add release workflows and NPM Trusted Publisher setup

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,9 @@
+# GitHub CODEOWNERS
+# This file defines code ownership for automatic review requests
+
+# Critical workflow files must be reviewed by repository owner
+/.github/workflows/release.yml @textlint-ja/admin
+/.github/workflows/create-release-pr.yml @textlint-ja/admin
+
+# CODEOWNERS file itself requires review to prevent bypassing protections
+/.github/CODEOWNERS @textlint-ja/admin

--- a/.github/workflows/create-release-pr.yml
+++ b/.github/workflows/create-release-pr.yml
@@ -1,0 +1,123 @@
+name: Create Release PR
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Version type'
+        required: true
+        type: choice
+        options:
+          - patch
+          - minor
+          - major
+
+jobs:
+  create-release-pr:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+      
+      - name: Configure Git
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+      
+      
+      - name: Setup Node.js
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: 'lts/*'
+      
+      # No need to install dependencies - npm version works without them
+      - name: Version bump
+        id: version
+        run: |
+          npm version "$VERSION_TYPE" --no-git-tag-version
+          VERSION=$(jq -r '.version' package.json)
+          echo "version=$VERSION" >> $GITHUB_OUTPUT
+        env:
+          VERSION_TYPE: ${{ github.event.inputs.version }}
+      
+      - name: Get release notes
+        id: release-notes
+        run: |
+          # Get the default branch
+          DEFAULT_BRANCH=$(gh api "repos/$GITHUB_REPOSITORY" --jq '.default_branch')
+          
+          # Get the latest release tag using GitHub API
+          # Use the exit code to determine if a release exists
+          if LAST_TAG=$(gh api "repos/$GITHUB_REPOSITORY/releases/latest" --jq '.tag_name' 2>/dev/null); then
+            echo "Previous release found: $LAST_TAG"
+          else
+            LAST_TAG=""
+            echo "No previous releases found - this will be the first release"
+          fi
+          
+          # Generate release notes - only include previous_tag_name if we have a valid previous tag
+          echo "Generating release notes for tag: v$VERSION"
+          if [ -n "$LAST_TAG" ]; then
+            echo "Using previous tag: $LAST_TAG"
+            RELEASE_NOTES=$(gh api \
+              --method POST \
+              -H "Accept: application/vnd.github+json" \
+              "/repos/$GITHUB_REPOSITORY/releases/generate-notes" \
+              -f "tag_name=v$VERSION" \
+              -f "target_commitish=$DEFAULT_BRANCH" \
+              -f "previous_tag_name=$LAST_TAG" \
+              --jq '.body')
+          else
+            echo "Generating notes from all commits"
+            RELEASE_NOTES=$(gh api \
+              --method POST \
+              -H "Accept: application/vnd.github+json" \
+              "/repos/$GITHUB_REPOSITORY/releases/generate-notes" \
+              -f "tag_name=v$VERSION" \
+              -f "target_commitish=$DEFAULT_BRANCH" \
+              --jq '.body')
+          fi
+          
+          # Set release notes as environment variable
+          echo "RELEASE_NOTES<<EOF" >> $GITHUB_ENV
+          echo "$RELEASE_NOTES" >> $GITHUB_ENV
+          echo "EOF" >> $GITHUB_ENV
+        env:
+          GH_TOKEN: ${{ github.token }}
+          VERSION: ${{ steps.version.outputs.version }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+
+      - name: Commit version bump
+        run: |
+          git add .
+          git commit -m "chore: release v$VERSION"
+        env:
+          VERSION: ${{ steps.version.outputs.version }}
+        
+      - name: Push branch
+        run: |
+          git push -u "https://x-access-token:${GH_TOKEN}@github.com/${GITHUB_REPOSITORY}.git" "HEAD:release/v$VERSION"
+        env:
+          VERSION: ${{ steps.version.outputs.version }}
+          GH_TOKEN: ${{ github.token }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+      
+      - name: Create Pull Request
+        run: |
+          echo "$RELEASE_NOTES" | gh pr create \
+            --title "Release v$VERSION" \
+            --body-file - \
+            --base "$BASE_BRANCH" \
+            --head "release/v$VERSION" \
+            --label "Type: Release" \
+            --assignee "$ACTOR"
+        env:
+          GH_TOKEN: ${{ github.token }}
+          VERSION: ${{ steps.version.outputs.version }}
+          BASE_BRANCH: ${{ github.ref_name }}
+          ACTOR: ${{ github.actor }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,132 @@
+name: Release
+
+on:
+  pull_request:
+    branches:
+      - master
+      - main
+    types:
+      - closed
+
+jobs:
+  release:
+    if: |
+      github.event.pull_request.merged == true &&
+      contains(github.event.pull_request.labels.*.name, 'Type: Release')
+    runs-on: ubuntu-latest
+    environment: 
+      name: npm
+    permissions:
+      contents: write
+      id-token: write  # OIDC
+    outputs:
+      released: ${{ steps.tag-check.outputs.exists == 'false' }}
+      version: ${{ steps.package.outputs.version }}
+      package-name: ${{ steps.package.outputs.name }}
+      release-url: ${{ steps.create-release.outputs.url }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+      
+      - name: Get package info
+        id: package
+        run: |
+          VERSION=$(jq -r '.version' package.json)
+          PACKAGE_NAME=$(jq -r '.name' package.json)
+          echo "version=$VERSION" >> $GITHUB_OUTPUT
+          echo "name=$PACKAGE_NAME" >> $GITHUB_OUTPUT
+      
+      - name: Check if tag exists
+        id: tag-check
+        run: |
+          if git rev-parse "v$VERSION" >/dev/null 2>&1; then
+            echo "exists=true" >> $GITHUB_OUTPUT
+          else
+            echo "exists=false" >> $GITHUB_OUTPUT
+          fi
+        env:
+          VERSION: ${{ steps.package.outputs.version }}
+      
+      
+      - name: Setup Node.js
+        if: steps.tag-check.outputs.exists == 'false'
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: 'lts/*'
+          registry-url: 'https://registry.npmjs.org'
+      
+      - name: Install dependencies
+        if: steps.tag-check.outputs.exists == 'false'
+        run: npm ci
+      
+      - name: Build package
+        if: steps.tag-check.outputs.exists == 'false'
+        run: npm run build
+      
+      - name: Publish to npm with provenance
+        if: steps.tag-check.outputs.exists == 'false'
+        run: npm publish --access public
+      
+      - name: Create GitHub Release with tag
+        id: create-release
+        if: steps.tag-check.outputs.exists == 'false'
+        run: |
+          RELEASE_URL=$(gh release create "v$VERSION" \
+            --title "v$VERSION" \
+            --target "$SHA" \
+            --notes "$PR_BODY")
+          echo "url=$RELEASE_URL" >> $GITHUB_OUTPUT
+        env:
+          GH_TOKEN: ${{ github.token }}
+          VERSION: ${{ steps.package.outputs.version }}
+          SHA: ${{ github.sha }}
+          PR_BODY: ${{ github.event.pull_request.body }}
+  
+  comment:
+    needs: release
+    if: |
+      always() && 
+      github.event_name == 'pull_request' && 
+      needs.release.outputs.released == 'true'
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+    steps:
+      - name: Comment on PR - Success
+        if: needs.release.result == 'success'
+        run: |
+          gh pr comment "$PR_NUMBER" \
+            --repo "$REPOSITORY" \
+            --body "✅ **Release v$VERSION completed successfully!**
+          
+          - 📦 npm package: https://www.npmjs.com/package/$PACKAGE_NAME/v/$VERSION
+          - 🏷️ GitHub Release: $RELEASE_URL
+          - 🔗 Workflow run: $SERVER_URL/$REPOSITORY/actions/runs/$RUN_ID"
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          VERSION: ${{ needs.release.outputs.version }}
+          PACKAGE_NAME: ${{ needs.release.outputs.package-name }}
+          RELEASE_URL: ${{ needs.release.outputs.release-url }}
+          SERVER_URL: ${{ github.server_url }}
+          REPOSITORY: ${{ github.repository }}
+          RUN_ID: ${{ github.run_id }}
+      
+      - name: Comment on PR - Failure
+        if: needs.release.result == 'failure'
+        run: |
+          gh pr comment "$PR_NUMBER" \
+            --repo "$REPOSITORY" \
+            --body "❌ **Release v$VERSION failed**
+          
+          Please check the workflow logs for details.
+          🔗 Workflow run: $SERVER_URL/$REPOSITORY/actions/runs/$RUN_ID"
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          VERSION: ${{ needs.release.outputs.version }}
+          SERVER_URL: ${{ github.server_url }}
+          REPOSITORY: ${{ github.repository }}
+          RUN_ID: ${{ github.run_id }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,6 +2,8 @@ name: test
 on: [push, pull_request]
 env:
   CI: true
+permissions:
+  contents: read
 jobs:
   test:
     name: "Test on Node.js ${{ matrix.node-version }}"
@@ -11,9 +13,11 @@ jobs:
         node-version: [ 18, 20 ]
     steps:
       - name: checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2.7.0
+        with:
+          persist-credentials: false
       - name: setup Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@f1f314fca9dfce2769ece7d933488f076716723e # v1.4.6
         with:
           node-version: ${{ matrix.node-version }}
       - name: Install

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,11 +13,11 @@ jobs:
         node-version: [ 18, 20 ]
     steps:
       - name: checkout
-        uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2.7.0
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
       - name: setup Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@f1f314fca9dfce2769ece7d933488f076716723e # v1.4.6
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: ${{ matrix.node-version }}
       - name: Install


### PR DESCRIPTION
## 概要

`/setup-release-pr` でGitHub Actionsのリリースワークフローを追加します。

## 変更内容

- `.github/workflows/create-release-pr.yml` - workflow_dispatchでバージョンバンプ用のリリースPRを作成
- `.github/workflows/release.yml` - "Type: Release" ラベル付きPRのマージでnpm公開（OIDC Trusted Publisher経由）+ GitHubリリース作成
- `.github/CODEOWNERS` - ワークフローファイルの保護
- `.github/workflows/test.yml` - 既存actionsをSHAピン留め + 最小権限(`contents: read`)追加（pinact/zizmor対応）

## リリース前に必要な手動設定

npmjs.comでNPM Trusted Publisher (OIDC) を設定する必要があります:

- Repository owner: `textlint-ja`
- Repository name: `textlint-rule-no-doubled-conjunction`
- Workflow name: `release.yml`
- Environment: `npm`

設定: https://www.npmjs.com/package/textlint-rule-no-doubled-conjunction/access

## 注意点

- releaseワークフローは `environment: npm` を使用。npm environmentに required reviewer `@azu` が設定されているため、リリースのたびに手動承認が必要
- スクリプト実行時に `⚠️ Reviewer may not be configured correctly. Response: undefined` の警告あり。npm environmentのreviewer設定を要確認
- CODEOWNERSは `@textlint-ja/admin` を参照。teamの存在/メンバーを要確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)
